### PR TITLE
Fixed bug in ProbingHashMap - clear() method was not clearing array

### DIFF
--- a/src/com/jwetherell/algorithms/data_structures/HashMap.java
+++ b/src/com/jwetherell/algorithms/data_structures/HashMap.java
@@ -514,7 +514,7 @@ public class HashMap<K, V> implements IMap<K,V> {
         @Override
         public void clear() {
             for (int i=0; i<array.length; i++)
-                array = null;
+                array[i] = null;
             size = 0;
         }
 


### PR DESCRIPTION
Fixed bug in ProbingHashMap - clear() method was not clearing array elements in the loop, missing square braces. I've added square braces to do what was planned.
