### PR TITLE
Fixed bug in ProbingHashMap - indexOf method could cause exception

### DIFF
--- a/src/com/jwetherell/algorithms/data_structures/HashMap.java
+++ b/src/com/jwetherell/algorithms/data_structures/HashMap.java
@@ -597,9 +597,9 @@ public class HashMap<K, V> implements IMap<K,V> {
          * @return Integer which represents the key.
          */
         private int indexOf(K key) {
-            int k = key.hashCode() % hashingKey;
-            if (k>=array.length)
-                k = k - ((k/array.length) * array.length);
+            int k = Math.abs(key.hashCode()) % hashingKey;
+            if (k >= array.length)
+                k = k - ((k / array.length) * array.length);
             return k;
         }
 


### PR DESCRIPTION
Fixed bug in ProbingHashMap - indexOf method could cause indexOutOfBoundariesException if the hashcode of a key was less than zero. I've added Math.abs(key.hashCode()) to prevent this.
