### PR TITLE
Fixed problem with inserting element to arraylist on large index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,9 @@ language: java
 
 jdk:
   - oraclejdk8
-#  - oraclejdk7
-#  - oraclejdk6
-
-#  - openjdk8
+  - oraclejdk7
   - openjdk7
-#  - oraclejdk7
+  - openjdk6
 
 env:
   - TEST_SUITE=run_tests
@@ -28,4 +25,6 @@ env:
 #  - TEST_SUITE=sorts
 
 script: "ant $TEST_SUITE"
+
+dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
+#  - oraclejdk7
 #  - oraclejdk6
 
 #  - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 before_script:
+ - sudo apt-get install ant-optional
  - export OPTS="-server -Xmx3072M"
  - export JAVA_OPTS="${JAVA_OPTS} ${OPTS}"
  - export ANT_OPTS="${ANT_OPTS} ${OPTS}"
@@ -9,7 +10,7 @@ language: java
 
 jdk:
   - oraclejdk8
-#  - oraclejdk7
+  - oraclejdk7
 #  - oraclejdk6
 
 #  - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
+#  - oraclejdk7
 #  - oraclejdk6
 
 #  - openjdk8
   - openjdk7
-  - openjdk6
+#  - oraclejdk7
 
 env:
   - TEST_SUITE=run_tests

--- a/src/com/jwetherell/algorithms/data_structures/List.java
+++ b/src/com/jwetherell/algorithms/data_structures/List.java
@@ -46,7 +46,8 @@ public abstract class List<T> implements IList<T> {
          * @param value to add to list.
          */
         public boolean add(int index, T value) {
-            if (size >= array.length)
+            size = Math.max(index, size);
+            while (size >= array.length)
                 grow();
             if (index==size) {
                 array[size] = value;

--- a/test/com/jwetherell/algorithms/data_structures/test/ListTests.java
+++ b/test/com/jwetherell/algorithms/data_structures/test/ListTests.java
@@ -1,5 +1,6 @@
 package com.jwetherell.algorithms.data_structures.test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
@@ -152,6 +153,14 @@ public class ListTests {
                 }
             }
         }
+    }
+
+    @Test
+    public void testInsertElementFarInArrayList() {
+        List.ArrayList<Integer> aList = new List.ArrayList<Integer>();
+        aList.add(2000000, 10);
+        assertEquals(aList.get(2000000), 10);
+
     }
 
     @Test


### PR DESCRIPTION
Inserting element on position larger then _size_ was causing exception - IMO it's counter intuitive because if we can insert element on position larger then size of list (list size + 1) then probably we should be able to insert it on any position.