### PR TITLE
fix the bug in grow()

### DIFF
--- a/src/com/jwetherell/algorithms/data_structures/Queue.java
+++ b/src/com/jwetherell/algorithms/data_structures/Queue.java
@@ -113,7 +113,7 @@ public interface Queue<T> extends IQueue<T> {
 
         // Grow the array by 50% and rearrange to make sequential
         private void grow(int size) {
-            int growSize = (size + (size<<1));
+            int growSize = (size + (size>>1));
             T[] temp = (T[]) new Object[growSize];
             // Since the array can wrap around, make sure you grab the first chunk 
             int adjLast = lastIndex % array.length;


### PR DESCRIPTION
According to the comment of grow() method, the size is supposed to grow 50% each time. However, right now the implementation has`int growSize = size + (size << 1)` will actually grow the size 3 times instead of 50%

<!--
Hi!
Thanks for considering contributing to this ever-growing list of algorithm and data structure implementations in java.
Your contribution is valuable.
In order to help us evaluate PRs better, we ask you to have a look at the following declaration and check the points you agree with. ( [x] )
PRs which don't agree to all the points mentioned below will be rejected. 
-->


#### By submitting this pull request I confirm I've read and complied with the below requirements.

- [x] I have read the [Contribution guidelines](CONTRIBUTING.md) and I am confident that my PR reflects them.
- [x] I have followed the [coding guidelines](CONTRIBUTING.md#cs) for this project.
- [x] My code follows the [skeleton code structure](CONTRIBUTING.md#sample).
- [x] This pull request has a descriptive title. For example, `Added {Algorithm/DS name} [{Language}]`, not `Update README.md` or `Added new code`.
