### PR TITLE
Fix functions getHeadValue and toString to return null when size is 0 in binaryheap.java

### DIFF
--- a/src/com/jwetherell/algorithms/data_structures/BinaryHeap.java
+++ b/src/com/jwetherell/algorithms/data_structures/BinaryHeap.java
@@ -341,7 +341,7 @@ public interface BinaryHeap<T extends Comparable<T>> extends IHeap<T> {
          */
         @Override
         public T getHeadValue() {
-            if (array.length == 0) return null;
+            if (array.length == 0 || size == 0) return null;
             return array[0];
         }
 
@@ -372,7 +372,7 @@ public interface BinaryHeap<T extends Comparable<T>> extends IHeap<T> {
         protected static class HeapPrinter {
 
             public static <T extends Comparable<T>> String getString(BinaryHeapArray<T> tree) {
-                if (tree.array.length == 0)
+                if (tree.array.length == 0 || size == 0)
                     return "Tree has no nodes.";
 
                 T root = tree.array[0];

--- a/test/com/jwetherell/algorithms/data_structures/test/common/HeapTest.java
+++ b/test/com/jwetherell/algorithms/data_structures/test/common/HeapTest.java
@@ -162,7 +162,17 @@ public class HeapTest {
             Utils.handleError(sorted,heap);
             return false;
         }
-
+        
+        for (int i = 0; i < quarter; i++) {
+            boolean added = heap.add(item);
+        }
+        T item = Utils.parseT(unsorted[0], type);
+        heap.clear();
+        if (heap.contains(item) || heap.getHeadValue() != null || heap.size() != 0) {
+                System.err.println(name+" YIKES!! " + item + " doesn't exists but has been shown.");
+                Utils.handleError(sorted,heap);
+                return false;
+        }
         return true;
     }
 }


### PR DESCRIPTION
Edited functions getHeadValue and toString in binaryHeapArray in file binaryheap.java to return null when size is 0

EDIT: Also added corresponding test cases.

- [x] I have read the [Contribution guidelines](CONTRIBUTING.md) and I am confident that my PR reflects them.
- [x] I have followed the [coding guidelines](CONTRIBUTING.md#cs) for this project.
- [x] My code follows the [skeleton code structure](CONTRIBUTING.md#sample).
- [x] This pull request has a descriptive title. For example, `Added {Algorithm/DS name} [{Language}]`, not `Update README.md` or `Added new code`.
