### PR TITLE
Broken KdNode equals and compareTo causes the KdTree not to return all valid results

### DIFF
--- a/src/com/jwetherell/algorithms/data_structures/KdTree.java
+++ b/src/com/jwetherell/algorithms/data_structures/KdTree.java
@@ -588,7 +588,8 @@ public class KdTree<T extends KdTree.XYZPoint> implements Iterable<T> {
          */
         @Override
         public int compareTo(KdNode o) {
-            return compareTo(depth, k, this.id, o.id);
+            int depthCompare = Integer.compare(this.depth, o.depth);
+            return depthCompare != 0 ? depthCompare : this.id.compareTo(o.id);
         }
 
         /**

--- a/test/com/jwetherell/algorithms/data_structures/test/KdTreeTests.java
+++ b/test/com/jwetherell/algorithms/data_structures/test/KdTreeTests.java
@@ -1,15 +1,16 @@
 package com.jwetherell.algorithms.data_structures.test;
 
-import com.jwetherell.algorithms.data_structures.KdTree;
-import com.jwetherell.algorithms.data_structures.KdTree.XYZPoint;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import com.jwetherell.algorithms.data_structures.KdTree;
+import com.jwetherell.algorithms.data_structures.KdTree.XYZPoint;
 
 public class KdTreeTests {
 
@@ -31,11 +32,11 @@ public class KdTreeTests {
         KdTree<XYZPoint> kdTree = new KdTree<XYZPoint>(points);
 
         Collection<XYZPoint> result = kdTree.nearestNeighbourSearch(1, p3);
-        assertTrue("K-D Tree query error. query=(k=1, p=(9, 6)) returned=" + result, result.contains(p3));
+        assertTrue("K-D Tree query error. query=(k=1, p=(9, 6)) returned="+result, result.contains(p3));
 
         XYZPoint search = new XYZPoint(1, 4);
         result = kdTree.nearestNeighbourSearch(4, search);
-        assertTrue("K-D Tree query error. query=(k=4, p=(1, 4)) returned=" + result, (result.contains(p1) &&
+        assertTrue("K-D Tree query error. query=(k=4, p=(1, 4)) returned="+result, (result.contains(p1) &&
                 result.contains(p2) &&
                 result.contains(p4) &&
                 result.contains(p6))
@@ -69,7 +70,6 @@ public class KdTreeTests {
         for (final XYZPoint p : kdTree)
             assertTrue(kdTree.contains(p));
     }
-
 
     @Test
     public void testKdTreeNearestNeighbour() {

--- a/test/com/jwetherell/algorithms/data_structures/test/KdTreeTests.java
+++ b/test/com/jwetherell/algorithms/data_structures/test/KdTreeTests.java
@@ -1,15 +1,15 @@
 package com.jwetherell.algorithms.data_structures.test;
 
-import static org.junit.Assert.assertTrue;
+import com.jwetherell.algorithms.data_structures.KdTree;
+import com.jwetherell.algorithms.data_structures.KdTree.XYZPoint;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Test;
-
-import com.jwetherell.algorithms.data_structures.KdTree;
-import com.jwetherell.algorithms.data_structures.KdTree.XYZPoint;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class KdTreeTests {
 
@@ -31,14 +31,14 @@ public class KdTreeTests {
         KdTree<XYZPoint> kdTree = new KdTree<XYZPoint>(points);
 
         Collection<XYZPoint> result = kdTree.nearestNeighbourSearch(1, p3);
-        assertTrue("K-D Tree query error. query=(k=1, p=(9, 6)) returned="+result, result.contains(p3));
+        assertTrue("K-D Tree query error. query=(k=1, p=(9, 6)) returned=" + result, result.contains(p3));
 
         XYZPoint search = new XYZPoint(1, 4);
         result = kdTree.nearestNeighbourSearch(4, search);
-        assertTrue("K-D Tree query error. query=(k=4, p=(1, 4)) returned="+result, (result.contains(p1) &&
-                                                                                    result.contains(p2) &&
-                                                                                    result.contains(p4) &&
-                                                                                    result.contains(p6))
+        assertTrue("K-D Tree query error. query=(k=4, p=(1, 4)) returned=" + result, (result.contains(p1) &&
+                result.contains(p2) &&
+                result.contains(p4) &&
+                result.contains(p6))
         );
 
         kdTree.remove(p6);
@@ -67,6 +67,22 @@ public class KdTreeTests {
         KdTree<XYZPoint> kdTree = new KdTree<XYZPoint>(points);
 
         for (final XYZPoint p : kdTree)
-           assertTrue(kdTree.contains(p));
+            assertTrue(kdTree.contains(p));
+    }
+
+
+    @Test
+    public void testKdTreeNearestNeighbour() {
+        List<XYZPoint> points = new ArrayList<XYZPoint>();
+        XYZPoint p1 = new XYZPoint(0, 0, 0);
+        points.add(p1);
+        XYZPoint p2 = new XYZPoint(-1, 0, 1);
+        points.add(p2);
+        XYZPoint p3 = new XYZPoint(2, 0, -2);
+        points.add(p3);
+        KdTree<XYZPoint> kdTree = new KdTree<XYZPoint>(points);
+
+        Collection<XYZPoint> result = kdTree.nearestNeighbourSearch(3, p1);
+        assertEquals("K-D Tree query error. expected all points to be returned" + result, 3, result.size());
     }
 }


### PR DESCRIPTION
#### By submitting this pull request I confirm I've read and complied with the below requirements.

- [ ] I have read the [Contribution guidelines](CONTRIBUTING.md) and I am confident that my PR reflects them.
- [ ] I have followed the [coding guidelines](CONTRIBUTING.md#cs) for this project.
- [ ] My code follows the [skeleton code structure](CONTRIBUTING.md#sample).
- [X] This pull request has a descriptive title. For example, `Added {Algorithm/DS name} [{Language}]`, not `Update README.md` or `Added new code`.

I haven't done the above, so won't mark the checklist as the CONTRIBUTING.md file DOES NOT EXIST.

---------------------

**TL;DR;** Calling `kdTree.nearestNeighbourSearch(K, point)` where K >= the size of the tree should return all the tree elements - but sometimes it doesn't (whether it works or not depends on the points coordinates). This PR fixes it. For more details, read below.

--------------------

So first of all, thank you very much for this repository and all the implementations. I have been looking closely at the KdTree implementation to build my own and after extensive testing I noticed that this implementation is broken. Here is why:
1. In KdTree while finding all nearest neighbours we go down the tree and then travel up and to other branches to seek for more candidates until we find K of them. 
2. The visited nodes are added to `examined` HashSet so we don't visit an already visited branch.
3. The `Set.contains` method from java relies heavily on equals and hashcode implementations - objects equality must be checked carefully.
4. The KdNode equals implementation uses its own compareTo implementation, which in turn determines two KdNodes to be equal when:
- their two underlying points are on the same depth in the tree, and
- the two points have the one coordinate on the axis "related" to that depth (axis = depth%k) equal to each other
Which is already incorrect as those could be two completely different points 
5. The KdNode hashCode implementation uses also PointXYZ hashCode implementation which is extremely naive and basically calculates the sum of X, Y and Z. This makes it very easy to create two points that share same hashCode and because of the equals implementation mentioned above makes it possible that two KdNodes will collide and will appear to be "equal" from the perspective of a Set collection. Because of this collision a certain branch of the tree will not be visited at all and its nodes missed.
6. As a result when adding certain set of points to the tree (e.g. 3 of them) and querying the nearestNeighbors with k = the size of the tree (or higher) we won't get all the 3 points in return - which would be the expected behavior.

I have added a test case demonstrating this behavior + this small PR fixing it. I'm only fixing the compareTo method of the KdNode, but frankly also the hashCode implementations should be changed. 