### PR TITLE
Fixed #165. Fixed a bug where multiplication with zero caused an error

### DIFF
--- a/src/com/jwetherell/algorithms/mathematics/Multiplication.java
+++ b/src/com/jwetherell/algorithms/mathematics/Multiplication.java
@@ -188,6 +188,9 @@ public class Multiplication {
             zeroCheck = false;
             sb.append(s);
         }
+        if(sb.length()==0){
+            return "0";
+        }
         return sb.toString();
     }
 

--- a/test/com/jwetherell/algorithms/mathematics/test/MathematicsTest.java
+++ b/test/com/jwetherell/algorithms/mathematics/test/MathematicsTest.java
@@ -308,5 +308,27 @@ public class MathematicsTest {
         for (int composite : compositeNumbers)
             assertFalse("Miller-Rabin test error. " + composite, Primes.millerRabinTest(composite));
     }
+
+    @Test
+    public void testMultiplyUsingLoopsWithStringInputZero1(){
+        long result = Integer.parseInt(Multiplication.multiplyUsingLoopWithStringInput("0", "3"));
+        long expected = 0;
+        // Requirement:
+        // When multiplying two values where one or both is zero the result should be zero
+        assertTrue(result == expected);
+    }
+
+    @Test
+    public void testMultiplyUsingLoopsWithStringInputZero2(){
+        long result1 = Integer.parseInt(Multiplication.multiplyUsingLoopWithStringInput("0000", "0000"));
+        long result2 = Integer.parseInt(Multiplication.multiplyUsingLoopWithStringInput("0000", "99"));
+        long result3 = Integer.parseInt(Multiplication.multiplyUsingLoopWithStringInput("99", "0000"));
+        long expected = 0;
+        // Requirement:
+        // When multiplying two values where one or both is zero the result should be zero
+        assertTrue(result1 == expected);
+        assertTrue(result2 == expected);
+        assertTrue(result3 == expected);
+    }
 }
 


### PR DESCRIPTION
The function `multiplyUsingLoopWithStringInput` in Multiplication.java can now handle zero inputs. Also added branch coverage for this. 

See issue #165 for more details.

#### By submitting this pull request I confirm I've read and complied with the below requirements.

- [x] I have read the [Contribution guidelines](CONTRIBUTING.md) and I am confident that my PR reflects them.
- [x] I have followed the [coding guidelines](CONTRIBUTING.md#cs) for this project.
- [x] My code follows the [skeleton code structure](CONTRIBUTING.md#sample).
- [x] This pull request has a descriptive title. For example, `Added {Algorithm/DS name} [{Language}]`, not `Update README.md` or `Added new code`.
