### PR TITLE
moved 10, 100 .. constants to the top of the Integer.Java file

### DIFF
--- a/src/com/jwetherell/algorithms/numbers/Integers.java
+++ b/src/com/jwetherell/algorithms/numbers/Integers.java
@@ -6,6 +6,14 @@ import java.util.Map;
 
 public class Integers {
 
+    // moved constants to the top of the class definition for better visibility
+    private static final int BILLION = 1000000000;
+    private static final int MILLION = 1000000;
+    private static final int THOUSAND = 1000;
+    private static final int HUNDRED = 100;
+    private static final int TEN = 10;
+
+
     private static final BigDecimal ZERO = new BigDecimal(0);
     private static final BigDecimal TWO = new BigDecimal(2);
 
@@ -137,11 +145,6 @@ public class Integers {
         multiDigits.put(90,"ninety");
     }
 
-    private static final int BILLION = 1000000000;
-    private static final int MILLION = 1000000;
-    private static final int THOUSAND = 1000;
-    private static final int HUNDRED = 100;
-    private static final int TEN = 10;
 
     private static final String handleUnderOneThousand(int number) {
         StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
Moved the definition of the below constants to the top of the file, instead of them being in the middle between methods.

private static final int BILLION = 1000000000;
private static final int MILLION = 1000000;
private static final int THOUSAND = 1000;
private static final int HUNDRED = 100;
private static final int TEN = 10;

