### PR TITLE
added way to send error for when dividing by zero

### DIFF
--- a/.project
+++ b/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1730486626683</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/src/com/jwetherell/algorithms/mathematics/Division.java
+++ b/src/com/jwetherell/algorithms/mathematics/Division.java
@@ -3,6 +3,9 @@ package com.jwetherell.algorithms.mathematics;
 public class Division {
 
     public static final long division(int a, int b) {
+        if (b == 0) {
+            throw new IllegalArgumentException("Divisor cannot be zero.");
+        }
         long result = ((long) a) / ((long) b);
         return result;
     }
@@ -10,7 +13,9 @@ public class Division {
     public static final long divisionUsingLoop(int a, int b) {
         int absA = Math.abs(a);
         int absB = Math.abs(b);
-
+        if (absB == 0) {
+            throw new IllegalArgumentException("Divisor cannot be zero.");
+        }
         long temp = absA;
         long result = 0;
         while (temp >= 0) {
@@ -24,7 +29,9 @@ public class Division {
     public static final long divisionUsingRecursion(int a, int b) {
         int absA = Math.abs(a);
         int absB = Math.abs(b);
-
+        if (absB == 0) {
+            throw new IllegalArgumentException("Divisor cannot be zero.");
+        }
         long result = 1;
         int diff = absA - absB;
         if (diff > 0 && diff <= 1) {
@@ -40,7 +47,9 @@ public class Division {
     public static final long divisionUsingMultiplication(int a, int b) {
         int absA = Math.abs(a);
         int absB = Math.abs(b);
-
+        if (absB == 0) {
+            throw new IllegalArgumentException("Divisor cannot be zero.");
+        }
         int temp = absB;
         int counter = 0;
         while (temp <= absA) {
@@ -58,7 +67,9 @@ public class Division {
         int absA = Math.abs(a);
         int absB = Math.abs(b);
         int tempA, tempB, counter;
-
+        if (absB == 0) {
+            throw new IllegalArgumentException("Divisor cannot be zero.");
+        }
         long result = 0L;
         while (absA >= absB) {
             tempA = absA >> 1; // Right shift "a"
@@ -78,6 +89,9 @@ public class Division {
     public static final long divisionUsingLogs(int a, int b) {
         long absA = Math.abs(a);
         long absB = Math.abs(b);
+        if (absB == 0) {
+            throw new IllegalArgumentException("Divisor cannot be zero.");
+        }
         double logBase10A = Math.log10(absA);
         double logBase10B = Math.log10(absB);
         double powOf10 = Math.pow(10, (logBase10A - logBase10B));


### PR DESCRIPTION
<!--
Hi!
Thanks for considering contributing to this ever-growing list of algorithm and data structure implementations in java.
Your contribution is valuable.
In order to help us evaluate PRs better, we ask you to have a look at the following declaration and check the points you agree with. ( [x] )
PRs which don't agree to all the points mentioned below will be rejected. 
-->

For this pull request I made changes to ensure that the program will not crash when dividing by zero. 
        if (b == 0) {
            throw new IllegalArgumentException("Divisor cannot be zero.");
        }
I tossed that if statement in every function for diving by zero
This is because you can't divide by 0, and since b is always the denominator, I can run a if statement on b
#### By submitting this pull request I confirm I've read and complied with the below requirements.

- [ ] I have read the [Contribution guidelines](CONTRIBUTING.md) and I am confident that my PR reflects them.
- [ ] I have followed the [coding guidelines](CONTRIBUTING.md#cs) for this project.
- [ ] My code follows the [skeleton code structure](CONTRIBUTING.md#sample).
- [ ] This pull request has a descriptive title. For example, `Added {Algorithm/DS name} [{Language}]`, not `Update README.md` or `Added new code`.
