### PR TITLE
handle when divisor b is zero in all division methods in Division.Java

### DIFF
--- a/src/com/jwetherell/algorithms/mathematics/Division.java
+++ b/src/com/jwetherell/algorithms/mathematics/Division.java
@@ -3,11 +3,17 @@ package com.jwetherell.algorithms.mathematics;
 public class Division {
 
     public static final long division(int a, int b) {
+        if (b == 0) {
+            throw new IllegalArgumentException("Divisor cannot be zero.");
+        }
         long result = ((long) a) / ((long) b);
         return result;
     }
 
     public static final long divisionUsingLoop(int a, int b) {
+        if (b == 0) {
+            throw new IllegalArgumentException("Divisor cannot be zero.");
+        }
         int absA = Math.abs(a);
         int absB = Math.abs(b);
 
@@ -22,6 +28,9 @@ public class Division {
     }
 
     public static final long divisionUsingRecursion(int a, int b) {
+        if (b == 0) {
+            throw new IllegalArgumentException("Divisor cannot be zero.");
+        }
         int absA = Math.abs(a);
         int absB = Math.abs(b);
 
@@ -38,6 +47,9 @@ public class Division {
     }
 
     public static final long divisionUsingMultiplication(int a, int b) {
+        if (b == 0) {
+            throw new IllegalArgumentException("Divisor cannot be zero.");
+        }
         int absA = Math.abs(a);
         int absB = Math.abs(b);
 
@@ -55,6 +67,9 @@ public class Division {
     }
 
     public static final long divisionUsingShift(int a, int b) {
+        if (b == 0) {
+            throw new IllegalArgumentException("Divisor cannot be zero.");
+        }
         int absA = Math.abs(a);
         int absB = Math.abs(b);
         int tempA, tempB, counter;
@@ -76,6 +91,9 @@ public class Division {
     }
 
     public static final long divisionUsingLogs(int a, int b) {
+        if (b == 0) {
+            throw new IllegalArgumentException("Divisor cannot be zero.");
+        }
         long absA = Math.abs(a);
         long absB = Math.abs(b);
         double logBase10A = Math.log10(absA);


### PR DESCRIPTION
This PR modifies all methods in Division.java to handle when the divisor, b is zero. This prevents potential runtime errors and improves the robustness of the code.