### PR TITLE
Fix zero input handling in multiplyUsingLoopWithStringInput

### DIFF
--- a/src/com/jwetherell/algorithms/mathematics/Multiplication.java
+++ b/src/com/jwetherell/algorithms/mathematics/Multiplication.java
@@ -126,6 +126,9 @@ public class Multiplication {
     }
 
     public static String multiplyUsingLoopWithStringInput(String a, String b) {
+        if (a.equals("0") || b.equals("0")){
+            return "0";
+        }
         int k,i,j,carry=0,rem,flag=0,lim1,lim2,mul;
 
         boolean aIsNegative = false;


### PR DESCRIPTION
This PR fixes an issue where multiplyUsingLoopWithStringInput fails when one or both inputs are "0".

An early return has been added to correctly handle zero input and prevent NumberFormatException, as described in issue #165.